### PR TITLE
Update cli.go

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"./vhd"
+	"go-vhd/vhd"
 	"fmt"
 	"github.com/codegangsta/cli"
 	"github.com/dustin/go-humanize"


### PR DESCRIPTION
Project can fail in the build/test process in case of relative path in the dependent projects.